### PR TITLE
Add multilingual support via Flask-Babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,9 @@ Create an `.env` file in the project root directory (use `.env.example` as a tem
 
 # --- Log Level (Optional) ---
 # LOGLEVEL=DEBUG  # More detailed logs (default is INFO)
+### Language Support
+MetaScreener supports English and Chinese user interfaces. Use the dropdown in the navigation bar to switch languages. Translations are stored in the `translations/` directory and managed with Flask-Babel.
+
 ```
 
 ## 📘 Usage Guide

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ distro==1.9.0
 et_xmlfile==2.0.0
 Flask>=2.0
 google-ai-generativelanguage==0.6.15
+Flask-Babel>=4.0.0
 google-api-core
 google-api-python-client==2.169.0
 google-auth==2.40.1

--- a/templates/base.html
+++ b/templates/base.html
@@ -61,24 +61,31 @@
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav mr-auto">
                 <li class="nav-item {% if request.endpoint == 'index' %}active{% endif %}">
-                    <a class="nav-link" href="{{ url_for('index') }}">Home</a>
+                    <a class="nav-link" href="{{ url_for('index') }}">{{ _("Home") }}</a>
                 </li>
                 <li class="nav-item {% if request.endpoint == 'llm_config_page' %}active{% endif %}">
-                    <a class="nav-link" href="{{ url_for('llm_config_page') }}">LLM Configuration</a>
+                    <a class="nav-link" href="{{ url_for('llm_config_page') }}">{{ _("LLM Configuration") }}</a>
                 </li>
                 <li class="nav-item {% if request.endpoint == 'screening_criteria_page' %}active{% endif %}">
-                    <a class="nav-link" href="{{ url_for('screening_criteria_page') }}">Screening Criteria</a>
+                    <a class="nav-link" href="{{ url_for('screening_criteria_page') }}">{{ _("Screening Criteria") }}</a>
                 </li>
                 <li class="nav-item {% if request.endpoint == 'abstract_screening_page' or request.endpoint == 'full_text_screening_page' or request.endpoint == 'screening_actions_page' %}active{% endif %}">
-                    <a class="nav-link" href="{{ url_for('screening_actions_page') }}">Screening Actions</a>
+                    <a class="nav-link" href="{{ url_for('screening_actions_page') }}">{{ _("Screening Actions") }}</a>
                 </li>
                 <li class="nav-item {% if request.endpoint == 'data_extraction_page' %}active{% endif %}">
-                    <a class="nav-link" href="{{ url_for('data_extraction_page') }}">Data Extraction</a>
+                    <a class="nav-link" href="{{ url_for('data_extraction_page') }}">{{ _("Data Extraction") }}</a>
                 </li>
                 <li class="nav-item {% if request.blueprint == 'quality_assessment' %}active{% endif %}">
-                    <a class="nav-link" href="{{ url_for('quality_assessment.upload_document_for_assessment') }}">Quality Assessment</a>
+                    <a class="nav-link" href="{{ url_for('quality_assessment.upload_document_for_assessment') }}">{{ _("Quality Assessment") }}</a>
                 </li>
             </ul>
+            <form class="form-inline my-2 my-lg-0" method="post" action="{{ url_for("set_language") }}">
+                <select class="form-control" name="language" onchange="this.form.submit()">
+                    {% for lang in languages %}
+                    <option value="{{ lang }}" {% if get_locale() == lang %}selected{% endif %}>{{ lang }}</option>
+                    {% endfor %}
+                </select>
+            </form>
         </div>
     </nav>
 
@@ -106,7 +113,7 @@
                     <span>© {{ current_year if current_year else namespace(current_year=2024).current_year }} MetaScreener. Use responsibly.</span>
                 </div>
                 <div class="col-md-6 text-center text-md-right">
-                    <a href="#" class="mr-3" data-toggle="modal" data-target="#disclaimerModal">Disclaimer</a>
+                    <a href="#" class="mr-3" data-toggle="modal" data-target="#disclaimerModal">{{ _("Disclaimer") }}</a>
                     <a href="https://www.metascreener.net/" class="mr-3" target="_blank">Official Website</a>
                     <a href="https://metascreener.onrender.com" target="_blank">Alternative Site</a>
                 </div>
@@ -147,18 +154,17 @@
         <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="disclaimerModalLabel">Disclaimer</h5>
+                    <h5 class="modal-title" id="disclaimerModalLabel">{{ _("Disclaimer") }}</h5>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
                 </div>
                 <div class="modal-body">
-                    <p>MetaScreener is provided "as-is" without any warranties of any kind, express or implied. The accuracy of AI-driven screening and data extraction heavily depends on the chosen LLM, the quality of the input data, and the clarity of the defined criteria.</p>
-                    <p>Users are solely responsible for verifying all results and making final decisions. The developers assume no liability for any outcomes resulting from the use of this software.</p>
-                    <p>Please use responsibly and in accordance with all applicable ethical guidelines and institutional policies.</p>
-                </div>
+                    <p>{{ _("MetaScreener is provided 'as-is' without any warranties of any kind, express or implied. The accuracy of AI-driven screening and data extraction heavily depends on the chosen LLM, the quality of the input data, and the clarity of the defined criteria.") }}</p>
+                    <p>{{ _("Users are solely responsible for verifying all results and making final decisions. The developers assume no liability for any outcomes resulting from the use of this software.") }}</p>
+                    <p>{{ _("Please use responsibly and in accordance with all applicable ethical guidelines and institutional policies.") }}</p>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ _("Close") }}</button>
                 </div>
             </div>
         </div>

--- a/translations/zh/LC_MESSAGES/messages.po
+++ b/translations/zh/LC_MESSAGES/messages.po
@@ -1,0 +1,86 @@
+msgid "Home"
+msgstr "主页"
+
+msgid "LLM Configuration"
+msgstr "LLM配置"
+
+msgid "Screening Criteria"
+msgstr "筛选标准"
+
+msgid "Screening Actions"
+msgstr "筛选操作"
+
+msgid "Data Extraction"
+msgstr "数据提取"
+
+msgid "Quality Assessment"
+msgstr "质量评估"
+
+msgid "Disclaimer"
+msgstr "免责声明"
+
+msgid "Close"
+msgstr "关闭"
+
+msgid "MetaScreener is provided 'as-is' without any warranties of any kind, express or implied. The accuracy of AI-driven screening and data extraction heavily depends on the chosen LLM, the quality of the input data, and the clarity of the defined criteria."
+msgstr "MetaScreener 按“原样”提供，不附带任何明示或暗示的保证。AI 驱动的筛选和数据提取的准确性在很大程度上取决于所选择的 LLM、输入数据的质量以及所定义标准的清晰度。"
+
+msgid "Users are solely responsible for verifying all results and making final decisions. The developers assume no liability for any outcomes resulting from the use of this software."
+msgstr "用户应自行核实所有结果并做出最终决定。开发者对使用本软件造成的任何后果不承担责任。"
+
+msgid "Please use responsibly and in accordance with all applicable ethical guidelines and institutional policies."
+msgstr "请负责任地使用，并遵守所有适用的伦理准则和机构政策。"
+
+msgid "Invalid LLM Provider selected."
+msgstr "选择的 LLM 提供商无效。"
+
+msgid "LLM configuration saved successfully."
+msgstr "LLM 配置已成功保存。"
+
+msgid "Screening criteria and settings successfully saved!"
+msgstr "筛选标准和设置已成功保存！"
+
+msgid "Screening criteria have been reset to default values."
+msgstr "筛选标准已恢复为默认值。"
+
+msgid "Test session not found or expired."
+msgstr "测试会话未找到或已过期。"
+
+msgid "Test session data missing."
+msgstr "缺少测试会话数据。"
+
+msgid "No valid decisions (I/M/E) for comparison. Ensure you selected human decisions for some items."
+msgstr "没有可用于比较的有效决策(I/M/E)。请确保为部分条目选择了人工决策。"
+
+msgid "Screening results not found or may have expired."
+msgstr "未找到筛选结果或可能已过期。"
+
+msgid "Test session not found or expired. Please start a new test."
+msgstr "测试会话未找到或已过期。请开始新的测试。"
+
+msgid "Test screening is now handled via the progress button."
+msgstr "测试筛选现在通过进度按钮处理。"
+
+msgid "Could not find screening results data to download (it might have expired or been viewed already without download)."
+msgstr "无法找到可供下载的筛选结果数据（可能已过期或已被查看）。"
+
+msgid "No results found within the screening data to download."
+msgstr "筛选数据中没有可供下载的结果。"
+
+msgid "Failed to construct prompt..."
+msgstr "构建提示失败..."
+
+msgid "PDF screening result not found. It might have expired or was not processed correctly."
+msgstr "未找到 PDF 筛选结果。可能已过期或处理不正确。"
+
+msgid "No valid data extraction fields were defined."
+msgstr "未定义有效的数据提取字段。"
+
+msgid "Batch PDF screening results not found or may have expired."
+msgstr "批量 PDF 筛选结果未找到或可能已过期。"
+
+msgid "Batch PDF screening results for download not found or may have expired."
+msgstr "批量 PDF 筛选下载结果未找到或可能已过期。"
+
+msgid "No result items found within the batch data to download."
+msgstr "批量数据中没有可下载的结果项。"


### PR DESCRIPTION
## Summary
- add `Flask-Babel` to requirements
- initialise Babel in `app.py` and provide `/set_language` route
- expose language selector in `base.html`
- mark some strings for translation
- add Chinese translation file
- document language support in README

## Testing
- `python -m py_compile app.py quality_assessment/*.py utils.py config.py`
